### PR TITLE
Only autoload the rules when iptables_load files exists.

### DIFF
--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -13,5 +13,9 @@
   notify:
     - iptables load
 
+- stat: path=/etc/network/if-up.d/iptables_load
+  register: iptables_load_exist
+
 - name: Autoload the rules
   template: src=iptables_load.j2 dest=/etc/network/if-up.d/iptables_load owner=root group=root mode=751
+  when: iptables_load_exist.stat.exists


### PR DESCRIPTION
Now the default way to auto load the `iptables_load` file will crash under `Centos 6.5`
