### PR TITLE
Flush nat and mangle tables if iptables_flush_all is true.

### DIFF
--- a/templates/etc/iptables.rules.j2
+++ b/templates/etc/iptables.rules.j2
@@ -7,6 +7,10 @@
 # Clean all
 iptables -F
 iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
 {% endif %}
 
 # Accept all from localhost


### PR DESCRIPTION
Hi,

I started using your Stouts.iptables last week and noticed that the nat and mangle tables were not being flushed when reloading the rules even if iptables_flush_all was true.  Since I was testing out some nat rules via iptables_raw_rules, this was leading to duplicate and/or multiple variations of rules.  

I've forked your repository and created a branch to add those commands to the iptables_flush_all section of the iptables.rules.j2 template.

I have tested and it works on my system.

Let me know if these changes are acceptable and I'll make changes it you want.

Thanks - David