### PR TITLE
Use command module instead of shell.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: iptables load
-  shell: "{{iptables_rules_path}}"
+  command: "{{iptables_rules_path}}"


### PR DESCRIPTION
We don't need shell features to execute this one command. Ansible
documentation for shell module also says it is more secure to use
command module instead of shell module (for example with command
module there's no shell environment that could change the executed
command to a different one with alias).