### PR TITLE
Remove Debian vars.

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,1 @@
 ---
-
-iptables_confdir: /etc/iptables
-iptables_rules_path: "{{ iptables_confdir }}/rules.v4"  # Path to rule file


### PR DESCRIPTION
They are the same as in default/main.yml, thus unnecessary. Fixes issue #12